### PR TITLE
Compatibility with Ansible 2.0

### DIFF
--- a/templates/dumpall.j2
+++ b/templates/dumpall.j2
@@ -19,4 +19,4 @@ GROUPS Variables ("groups"):
 
 HOST Variables ("hostvars"):
 --------------------------------
-{{ hostvars | to_nice_json }}
+{{ hostvars[inventory_hostname] | to_nice_json }}


### PR DESCRIPTION
With original code, Ansible 2.0 got error:
> FAILED! => {"changed": false, "failed": true, "msg": "AnsibleError: ERROR! an unexpected type error occurred. Error was exceptions must be old-style classes or derived from BaseException, not type"}

This fix I checked with Ansible 2.0.0.2 and 1.9.4.
See https://github.com/ansible/ansible/issues/13838 for details.